### PR TITLE
Paparase filename was still citing minified one on licenses file

### DIFF
--- a/javascript_licenses.html
+++ b/javascript_licenses.html
@@ -34,9 +34,9 @@
         <td><a href="src/presets.js">src/presets.js</a></td>
     </tr>
     <tr>
-        <td><a href="lib/papaparse.min.js">lib/papaparse.js</a></td>
+        <td><a href="lib/papaparse.js">lib/papaparse.js</a></td>
         <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
-        <td><a href="lib/papaparse.min.js">lib/papaparse.js</a></td>
+        <td><a href="lib/papaparse.js">lib/papaparse.js</a></td>
     </tr>
     <tr>
         <td><a href="lib/cubic-spline.js">lib/cubic-spline.js</a></td>


### PR DESCRIPTION
commit 24db8f89 changed the hyperlink but not the text being hyperlinked, which 
confuses LibreJS and makes it unable to identify the license of the file

this commit changes the text to match the filename, fixing the problem