### PR TITLE
feature: allow custom time-frames (either in days or in injection cycles)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -170,6 +170,11 @@ th {
     margin-right: auto;
 }
 
+.centered-reflow {
+	display: flex;
+	justify-content: center;
+}
+
 #options-container {
     grid-area: options-container;
     display: flex;
@@ -400,11 +405,6 @@ button.delete-button {
 
     #the-big-light {
         align-items: bottom;
-    }
-
-    .centered-reflow {
-        display: flex;
-        justify-content: center;
     }
 
     #bottom-text {

--- a/index.html
+++ b/index.html
@@ -85,6 +85,11 @@
                 <button id="target-range-button" class="flat-button" title="Turn on/off the display of target mean estradiol range">
                     target range
                 </button>
+                <input id="abscissa-width" class="flat-input" value="5" title="x-Axis width">
+                <select id="abscissa-units" title="Change units for the x-Axis width concentration">
+                    <option value="cycles" selected>Injection Cycles</option>
+                    <option value="days">Days</option>
+                </select>
                 <button id="reset-button" class="flat-button" title="Click to clear all, double-click to reset to default.">
                     clear/reset
                 </button>

--- a/src/estrannaise.js
+++ b/src/estrannaise.js
@@ -44,6 +44,8 @@ window.addEventListener('DOMContentLoaded', () => {
     setupPresetsDropdown();
     setupMenstrualCycleButtonEvent();
     setupTargetRangeButtonEvent();
+    setupAbscissaWidth();
+    setupAbscissaUnitsDropdown();
     setupResetLocalStorageButtonEvent();
     setupShareURLButtonEvent();
 
@@ -176,6 +178,30 @@ function setupTargetRangeButtonEvent() {
             turnTargetRangeOn();
         }
     });
+}
+
+function setupAbscissaWidth() {
+    let abscissaWidthInput = document.getElementById('abscissa-width');
+
+    abscissaWidthInput.addEventListener('input', () => {
+        let abscissaWidth = parseInt(abscissaWidthInput.value);
+        if (!isNaN(abscissaWidth) && abscissaWidth > 0) {
+            refresh();
+            saveToLocalStorage();
+        }
+
+    });
+}
+
+function setupAbscissaUnitsDropdown() {
+
+    let dropdown = document.getElementById('abscissa-units');
+
+    dropdown.addEventListener('change', () => {
+        refresh();
+        saveToLocalStorage();
+    });
+
 }
 
 function setupResetLocalStorageButtonEvent() {
@@ -1024,6 +1050,8 @@ function saveToLocalStorage() {
             targetRangeVisible: isButtonOn('target-range-button'),
             units: document.getElementById('dropdown-units').value,
             fudgeFactor: document.getElementById('fudge-factor').value,
+            abscissaWidth: document.getElementById('abscissa-width').value,
+            abscissaUnits: document.getElementById('abscissa-units').value,
             daysAsIntervals: global_daysAsIntervals
         }));
 
@@ -1042,6 +1070,8 @@ function loadFromLocalStorage() {
         if (states.targetRangeVisible) { turnTargetRangeOn(false); } else { turnTargetRangeOff(false); }
         if (states.units) { document.getElementById('dropdown-units').value = states.units; }
         if (states.fudgeFactor) { document.getElementById('fudge-factor').value = states.fudgeFactor; }
+        if (states.abscissaWidth) { document.getElementById('abscissa-width').value = states.abscissaWidth; }
+        if (states.abscissaUnits) { document.getElementById('abscissa-units').value = states.abscissaUnits; }
     }
 
     // if the element entries exists in localStorage
@@ -1223,6 +1253,8 @@ function applyPreset(presetConfig, refreshAfter = true) {
     presetConfig.customdoses.daysAsIntervals ? setDaysAsIntervals(false) : setDaysAsAbsolute(false);
     presetConfig.units && (document.getElementById('dropdown-units').value = presetConfig.units);
     presetConfig.fudgeFactor > 0 && (document.getElementById('fudge-factor').value = presetConfig.fudgeFactor);
+    presetConfig.abscissaUnits && (document.getElementById('abscissa-units').value = presetConfig.abscissaUnits);
+    presetConfig.abscissaWidth > 0 && (document.getElementById('abscissa-width').value = presetConfig.abscissaWidth);
 
     if (presetConfig.steadystates.entries.length) {
         presetConfig.steadystates.entries.forEach(entry => {
@@ -1286,6 +1318,8 @@ export function getCurrentPlottingOptions() {
     let targetRangeVisible = isButtonOn('target-range-button');
     let units = document.getElementById('dropdown-units').value;
     let fudgeFactor = document.getElementById('fudge-factor').value;
+    let abscissaUnits = document.getElementById('abscissa-units').value;
+    let abscissaWidth = document.getElementById('abscissa-width').value;
 
     let numberOfLinePoints = 1000;
     let numberOfCloudPoints = 3500;
@@ -1315,6 +1349,8 @@ export function getCurrentPlottingOptions() {
         targetRangeVisible: targetRangeVisible,
         units: units,
         fudgeFactor: fudgeFactor,
+        abscissaWidth: abscissaWidth,
+        abscissaUnits: abscissaUnits,
         strokeWidth: strokeWidth,
         numberOfLinePoints: numberOfLinePoints,
         numberOfCloudPoints: numberOfCloudPoints,

--- a/src/presets.js
+++ b/src/presets.js
@@ -14,6 +14,8 @@ export const Presets = {
         targetRange: false,
         units: 'pg/mL',
         fudgeFactor: 1.0,
+        abscissaWidth: 5,
+        abscissaUnits: 'cycles',
         steadystates: {entries: []},
         customdoses: {
             curveVisible: true,
@@ -29,6 +31,8 @@ export const Presets = {
         targetRange: true,
         units: 'pg/mL',
         fudgeFactor: 1.0,
+        abscissaWidth: 5,
+        abscissaUnits: 'cycles',
         steadystates: {
             entries: [
                 {dose: 4, time: 7, model: 'EEn im', curveVisible: true, uncertaintyVisible: true},


### PR DESCRIPTION
- Added a field to select number of injection cycles/days shown in the plot. Still displays 5 cycles by default.
- Lowered the default minimum xMax value to 1 when displaying a custom amount of days.
- Made the _.centered-reflow_ always be a flex container. The new buttons take up more horizontal space and this ensures it is always centered. Previously, this was under a media query for width < 768px.