### PR TITLE
Allow for custom amount of days to be displayed

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -389,6 +389,34 @@ button.delete-button {
     margin-right: auto;
 }
 
+#days-shown {
+	padding: 0 0.8rem;
+	background-color: var(--standout-background-color);
+	color: var(--strong-foreground);
+	font-size: var(--font-size-for-dummies-like-safari);
+	border-radius: 0.35rem;
+}
+
+#days-input {
+	display: inline-block;
+	box-sizing: border-box;
+	appearance: textfield;
+	background-color: var(--standout-background-color);
+	color: var(--strong-foreground);
+	font-size: var(--font-size-for-dummies-like-safari);
+	border: 0;
+	width: 3em;
+	height: var(--element-height);
+	outline: 0;
+	text-align: center;
+}
+
+#days-tag {
+	display: inline-block;
+	height: var(--element-height);
+	line-height: var(--element-height);
+}
+
 @media (max-width: 768px) {
     #ui-container {
         grid-template-areas:

--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
                 <button id="target-range-button" class="flat-button" title="Turn on/off the display of target mean estradiol range">
                     target range
                 </button>
+                <div id="days-shown">
+                    <input id="days-input" value="0" title="Days to display" type="number" min="0" placeholder="Auto"> <span id="days-tag">days</span>
+                </div>
                 <button id="reset-button" class="flat-button" title="Click to clear all, double-click to reset to default.">
                     clear/reset
                 </button>

--- a/src/estrannaise.js
+++ b/src/estrannaise.js
@@ -44,6 +44,7 @@ window.addEventListener('DOMContentLoaded', () => {
     setupPresetsDropdown();
     setupMenstrualCycleButtonEvent();
     setupTargetRangeButtonEvent();
+    setupdaysShown();
     setupResetLocalStorageButtonEvent();
     setupShareURLButtonEvent();
 
@@ -175,6 +176,22 @@ function setupTargetRangeButtonEvent() {
         } else {
             turnTargetRangeOn();
         }
+    });
+}
+
+function setupdaysShown() {
+    let daysShownInput = document.getElementById('days-input');
+
+    daysShownInput.addEventListener('input', () => {
+
+        let daysShown = parseInt(daysShownInput.value);
+
+        if (isNaN(daysShown) || daysShown <= 0) {
+            daysShownInput.value = null;
+        }
+
+        refresh();
+        saveToLocalStorage();
     });
 }
 
@@ -1004,12 +1021,11 @@ function generateShareString() {
 
     let shareString = [stateString, customdoseString, steadyStateString].join('_');
 
-    if (!isNaN(parseFloat(document.getElementById('fudge-factor').value)) && parseFloat(document.getElementById('fudge-factor').value) !== 1.0) {
-        shareString += '_' + dropNaNAndFix(parseFloat(document.getElementById('fudge-factor').value));
-    }
+    shareString += '_' + dropNaNAndFix(parseFloat(document.getElementById('fudge-factor').value));
+
+    shareString += '_' + dropNaNAndFix(parseInt(document.getElementById('days-input').value));
 
     return shareString
-
 }
 
 function generateShareURL() {
@@ -1024,6 +1040,7 @@ function saveToLocalStorage() {
             targetRangeVisible: isButtonOn('target-range-button'),
             units: document.getElementById('dropdown-units').value,
             fudgeFactor: document.getElementById('fudge-factor').value,
+            daysShown: document.getElementById('days-input').value,
             daysAsIntervals: global_daysAsIntervals
         }));
 
@@ -1042,6 +1059,7 @@ function loadFromLocalStorage() {
         if (states.targetRangeVisible) { turnTargetRangeOn(false); } else { turnTargetRangeOff(false); }
         if (states.units) { document.getElementById('dropdown-units').value = states.units; }
         if (states.fudgeFactor) { document.getElementById('fudge-factor').value = states.fudgeFactor; }
+        if (states.daysShown) { document.getElementById('days-input').value = states.daysShown; }
     }
 
     // if the element entries exists in localStorage
@@ -1089,7 +1107,7 @@ function loadFromStateString(stateString) {
 
     let [unitsMap, modelsMap] = [generateEnum(availableUnits), generateEnum(modelList)];
 
-    let [state, customdose, steadyState, fudgeFactor] = stateString.split('_');
+    let [state, customdose, steadyState, fudgeFactor, daysShown] = stateString.split('_');
     state.includes('i') ? setDaysAsIntervals(false) : setDaysAsAbsolute(false);
     state.includes('m') ? turnMenstrualCycleOn(false) : turnMenstrualCycleOff(false);
     state.includes('t') ? turnTargetRangeOn(false) : turnTargetRangeOff(false);
@@ -1099,6 +1117,7 @@ function loadFromStateString(stateString) {
     if (!isNaN(parseFloat(fudgeFactor))) {
         document.getElementById('fudge-factor').value = fudgeFactor;
     }
+    document.getElementById('days-input').value = (isNaN(parseInt(daysShown)) ? null : parseInt(daysShown));
 
     let mdEntries = customdose.split('-');
     deleteAllRows('customdose-table');
@@ -1223,6 +1242,7 @@ function applyPreset(presetConfig, refreshAfter = true) {
     presetConfig.customdoses.daysAsIntervals ? setDaysAsIntervals(false) : setDaysAsAbsolute(false);
     presetConfig.units && (document.getElementById('dropdown-units').value = presetConfig.units);
     presetConfig.fudgeFactor > 0 && (document.getElementById('fudge-factor').value = presetConfig.fudgeFactor);
+    document.getElementById('days-input').value = presetConfig.daysShown;
 
     if (presetConfig.steadystates.entries.length) {
         presetConfig.steadystates.entries.forEach(entry => {
@@ -1286,6 +1306,7 @@ export function getCurrentPlottingOptions() {
     let targetRangeVisible = isButtonOn('target-range-button');
     let units = document.getElementById('dropdown-units').value;
     let fudgeFactor = document.getElementById('fudge-factor').value;
+    let daysShown = document.getElementById('days-input').value;
 
     let numberOfLinePoints = 1000;
     let numberOfCloudPoints = 3500;
@@ -1315,6 +1336,7 @@ export function getCurrentPlottingOptions() {
         targetRangeVisible: targetRangeVisible,
         units: units,
         fudgeFactor: fudgeFactor,
+        daysShown: daysShown,
         strokeWidth: strokeWidth,
         numberOfLinePoints: numberOfLinePoints,
         numberOfCloudPoints: numberOfCloudPoints,

--- a/src/plotting.js
+++ b/src/plotting.js
@@ -40,6 +40,7 @@ export function generatePlottingOptions({
     targetRangeVisible = false,
     units = 'pg/mL',
     fudgeFactor = 1.0,
+    daysShown = 0,
     strokeWidth = 2,
     numberOfLinePoints = 900,
     numberOfCloudPoints = 3500,
@@ -57,6 +58,7 @@ export function generatePlottingOptions({
             targetRangeVisible,
             units,
             fudgeFactor,
+            daysShown,
             strokeWidth,
             numberOfLinePoints,
             numberOfCloudPoints,
@@ -75,26 +77,36 @@ export function generatePlottingOptions({
 function findxMax(dataset, options) {
 
     // Initialize absolute minimum for the time axis
-    let xMax = 14.1;
+    let xMax = 1;
 
     // At least one menstrual cycle
     if (options.menstrualCycleVisible) xMax = 28.2;
 
-    // At least 5 injection cycles
-    xMax = Math.max(xMax, ...dataset.steadystates.entries.filter(entry => entry.curveVisible || entry.uncertaintyVisible).map(entry => 5 * entry.time));
+    // Check if user has selected how many days to display
+    if (options.daysShown > 0) {
+        xMax = Math.max(xMax, options.daysShown);
+    }
+    // Defaulting to 5 injection cycles
+    else {
+        // Initialize absolute minimum for the time axis
+        xMax = Math.max(xMax, 14.1);
+        
+        // At least 5 injection cycles
+        xMax = Math.max(xMax, ...dataset.steadystates.entries.filter(entry => entry.curveVisible || entry.uncertaintyVisible).map(entry => 5 * entry.time));
 
-    // At least injection time plus 5 approximate terminal half-lives ( 5 x log 2 / smallest k )
-    if (dataset.customdoses.entries.length > 0 && (dataset.customdoses.curveVisible || dataset.customdoses.uncertaintyVisible)) {
-        if (dataset.customdoses.daysAsIntervals) {
-            let absoluteTimes = dataset.customdoses.entries.reduce((acc, entry, idx) => {
-                // Ignore first entry in interval days
-                if (idx === 0) { acc.push(0); }
-                else { acc.push(acc[idx - 1] + entry.time); }
-                return acc;
-            }, []);
-            xMax = Math.max(xMax, ...dataset.customdoses.entries.map((entry, idx) => absoluteTimes[idx] + terminalEliminationTime3C(...PKParameters[entry.model])));
-        } else {
-            xMax = Math.max(xMax, ...dataset.customdoses.entries.map(entry => entry.time + terminalEliminationTime3C(...PKParameters[entry.model])));
+        // At least injection time plus 5 approximate terminal half-lives ( 5 x log 2 / smallest k )
+        if (dataset.customdoses.entries.length > 0 && (dataset.customdoses.curveVisible || dataset.customdoses.uncertaintyVisible)) {
+            if (dataset.customdoses.daysAsIntervals) {
+                let absoluteTimes = dataset.customdoses.entries.reduce((acc, entry, idx) => {
+                    // Ignore first entry in interval days
+                    if (idx === 0) { acc.push(0); }
+                    else { acc.push(acc[idx - 1] + entry.time); }
+                    return acc;
+                }, []);
+                xMax = Math.max(xMax, ...dataset.customdoses.entries.map((entry, idx) => absoluteTimes[idx] + terminalEliminationTime3C(...PKParameters[entry.model])));
+            } else {
+                xMax = Math.max(xMax, ...dataset.customdoses.entries.map(entry => entry.time + terminalEliminationTime3C(...PKParameters[entry.model])));
+            }
         }
     }
 
@@ -130,7 +142,7 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
 
     let yMax = options.fudgeFactor * conversionFactor / 1.25;
     let xMin = 0;
-    let xMax = Math.max(14.1, findxMax(dataset, options));
+    let xMax = Math.max(1, findxMax(dataset, options));
 
     let dotMarks  = [],
         lineMarks = [],


### PR DESCRIPTION
Second stab at it!
- Modified the URL generation: URL's will have a fixed amount of underscores as to properly identifying fields. New fields may be added in the future by appending more underscore-separated fields.
- Defaults to 5 injection cycles.
- Backwards compatible with previous versions' URLs, as the new _days_ field is appended at the end. If it doesn't exist in the URL, it falls back to the default value. Again, this is future-proof: if new fields are appended at the end, the _days_ will remain in the 4th position.
- Also falls back to default values if an invalid (0, negative, or non-numeric) value is entered.
- To make it more understandable, I've added a label next to the _days_ input, but it does take up more space. I can remove it to save on horizontal space.
![image](https://github.com/user-attachments/assets/2353fb79-3558-40eb-ab0c-7156f9d21acb)
