### PR TITLE
POC for customizable wear time for patches (see #38)

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
                                 <th>dose</th>
                                 <th>every</th>
                                 <th>model</th>
+                                <th>days worn</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -152,6 +153,7 @@
                                     </select>
                                 </th>
                                 <th>model</th>
+                                <th>days worn</th>
                                 <th></th>
                             </tr>
                         </thead>

--- a/index.html
+++ b/index.html
@@ -242,9 +242,7 @@
                 See the list of references above. Based on insights from self-reported community data, it
                 is important to note that both models significantly underestimate uncertainty, which is
                 likely closer to ten times greater than currently represented. Future updates will aim to
-                address this discrepancy. Additionally, the interface currently does not allow for adjustments
-                to the patch wearing period (they are fixed at 3&frac12; and 7 days) though this
-                functionality is planned in future updates.
+                address this discrepancy.
             </p>
 
             <p class="indent">Menstrual cycle data were sourced from
@@ -334,7 +332,8 @@
             <p>
                 mit license (c) 2025 alix<br>
                 <a href="javascript_licenses.html" data-jslicense="1">JavaScript license information</a><br>
-                <a href="https://github.com/WHSAH/estrannaise.js" target="_blank">estrannaise.js (v0.4.0)</a>
+                <a href="https://github.com/WHSAH/estrannaise.js" target="_blank">estrannaise.js (v0.4.0)</a><br>
+                <a href="https://github.com/bertille-ddp/estrannaise.js/" target="_blank">Patch wearing period functionality</a>
             </p>
             <br>
             <p>

--- a/src/estrannaise.js
+++ b/src/estrannaise.js
@@ -888,7 +888,7 @@ function addDoseTimeModelRow(tableID, dose = null, time = null, model = null, wo
     wornforInput.type = 'number';
 
     wornforInput.classList.add('wornfor-input');
-    wornforInput.placeholder = 'only for patches';
+    wornforInput.placeholder = 'patches only';
 
     if (tableID == 'customdose-table') {
         wornforInput.classList.add('wornfor-input-customdose');

--- a/src/modeldata.js
+++ b/src/modeldata.js
@@ -48,8 +48,8 @@ export const modelList = {
     'EC im': {units: 'mg', description: 'Estradiol Cypionate, Intramuscular'},
     'EUn im': {units: 'mg', description: 'Estradiol Undecylate, Intramuscular'},
     'EUn casubq': {units: 'mg', description: 'Estradiol Undecylate in Castor oil, Subcutaneous'},
-    'patch tw': {units: 'mcg/day', description: 'Patch, twice weekly application'},
-    'patch ow': {units: 'mcg/day', description: 'Patch, once weekly application'}
+    'patch tw': {units: 'mcg/day', description: 'Patch, made for twice weekly application', wornfor: 3.5},
+    'patch ow': {units: 'mcg/day', description: 'Patch, made for once weekly application', wornfor: 7.0}
 };
 
 /**

--- a/src/plotting.js
+++ b/src/plotting.js
@@ -201,13 +201,14 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
         let doses = dataset.customdoses.entries.map(entry => entry.dose);
         let times = dataset.customdoses.entries.map(entry => entry.time);
         let models = dataset.customdoses.entries.map(entry => entry.model);
+        let wearperiods = dataset.customdoses.entries.map(entry => entry.wornfor);
 
         if (dataset.customdoses.uncertaintyVisible) {
             let customdoseUncertaintyCloud = [];
 
             for (let i = 0; i < options.numberOfCloudPoints; i++) {
                 let randx = Math.random() * (xMax - xMin) + xMin;
-                let y = e2multidose3C(randx, doses, times, models, options.fudgeFactor * conversionFactor, true, dataset.customdoses.daysAsIntervals);
+                let y = e2multidose3C(randx, doses, times, models, wearperiods, options.fudgeFactor * conversionFactor, true, dataset.customdoses.daysAsIntervals);
                 customdoseUncertaintyCloud.push({ Time: randx, E2: y });
             }
 
@@ -221,7 +222,7 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
         }
 
         // Always compute the curve to set the y-axis limit
-        let customdoseCurve = fillCurve(t => e2multidose3C(t, doses, times, models, options.fudgeFactor * conversionFactor, false, dataset.customdoses.daysAsIntervals), xMin, xMax, options.numberOfLinePoints);
+        let customdoseCurve = fillCurve(t => e2multidose3C(t, doses, times, models, wearperiods, options.fudgeFactor * conversionFactor, false, dataset.customdoses.daysAsIntervals), xMin, xMax, options.numberOfLinePoints);
         yMax = Math.max(yMax, ...customdoseCurve.map(p => p.E2));
 
         if (dataset.customdoses.curveVisible) {
@@ -254,7 +255,7 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
 
             for (let i = 0; i < options.numberOfCloudPoints; i++) {
                 let randx = Math.random() * (xMax - xMin) + xMin;
-                let y = PKRandomFunctions(options.fudgeFactor * conversionFactor)[entry.model](randx, entry.dose, true, entry.time)
+                let y = PKRandomFunctions(options.fudgeFactor * conversionFactor)[entry.model](randx, entry.dose, true, entry.time, null, entry.wornfor)
                 steadyStateUncertaintyCloud.push({
                     Time: randx,
                     E2: y
@@ -269,7 +270,7 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
             }));
         }
 
-        let steadyStateCurve = fillCurve(t => PKFunctions(options.fudgeFactor * conversionFactor)[entry.model](t, entry.dose, true, entry.time), xMin, xMax, options.numberOfLinePoints);
+        let steadyStateCurve = fillCurve(t => PKFunctions(options.fudgeFactor * conversionFactor)[entry.model](t, entry.dose, true, entry.time, entry.wornfor), xMin, xMax, options.numberOfLinePoints);
         yMax = Math.max(yMax, ...steadyStateCurve.map(p => p.E2));
 
         if (entry.curveVisible) {

--- a/src/plotting.js
+++ b/src/plotting.js
@@ -312,7 +312,7 @@ export function plotCurves(dataset, options = generatePlottingOptions(), returnS
         marginTop: 30,
         x: { domain: [xMin, xMax], label: 'time (days)', ticks: 7 },
         y: { domain: [0, 1.25 * yMax], label: `serum e₂ (${units})` + (options.fudgeFactor != 1 ? ` (fudge x${options.fudgeFactor})` : ''), ticks: 6 },
-        style: { fontFamily: 'monospace', fontSize: options.fontSize },
+        style: { fontFamily: 'monospace', fontSize: options.fontSize, margin: '0 auto' },
         marks: [].concat(gridMarks)
          .concat(targetMarks)
          .concat(msMarks)

--- a/src/presets.js
+++ b/src/presets.js
@@ -42,7 +42,7 @@ export const Presets = {
             entries: [
                 {dose: 4, time: 0, model: 'EV im'},
                 {dose: 4, time: 20, model: 'EEn im'},
-                {dose: 100, time: 30, model: 'patch ow'}
+                {dose: 100, time: 30, model: 'patch ow', wornfor: 7.0}
                 ]
             }
     },
@@ -208,8 +208,8 @@ export const Presets = {
         label: 'Patch monotherapies (once/twice weekly)',
         menstrualCycle: false,
         steadystates: {entries: [
-            {dose: 400, time: 3.5, model: 'patch tw', curveVisible: true, uncertaintyVisible: true},
-            {dose: 300, time: 7, model: 'patch ow', curveVisible: true, uncertaintyVisible: true}
+            {dose: 400, time: 3.5, model: 'patch tw', wornfor: 3.5, curveVisible: true, uncertaintyVisible: true},
+            {dose: 300, time: 7, model: 'patch ow', wornfor: 7.0, curveVisible: true, uncertaintyVisible: true}
         ]},
         customdoses: {
             curveVisible: true,


### PR DESCRIPTION
Hi!
I wanted to explore how patches’ turnover can smooth E2 levels and allow for higher average and through levels while maintaining a good stability. In order to do so, I needed to have a finer control over patches’ wear time so I tried tinkering a bit with the code base.
I don’t know a thing about JS or UX design so I don’t think this PR can be merge as-is, but it’s functional enough to experiment with the curves!

Things I didn’t do:
- edit the main page’s paragraph about patches to announce this new functionality
- figure out how to hide the new 'days worn' field when there isn’t any patch in the rows

Feel free to choose any other wording in the code or UI! English isn’t my first language and what I chose may not be the clearest options